### PR TITLE
Update gulp to work with node v7.2.x

### DIFF
--- a/generators/app/templates/commonjs/package.json
+++ b/generators/app/templates/commonjs/package.json
@@ -13,7 +13,7 @@
     "browser-sync": "^2.18.0",
     "browserify": "^13.1.0",
     "del": "^2.2.0",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-cached": "^1.1.0",
     "gulp-eslint": "^3.0.0",
     "gulp-if": "^2.0.1",


### PR DESCRIPTION
Updated gulp to v3.9.1 based on suggestion found in https://github.com/gulpjs/gulp/issues/1843